### PR TITLE
Support language Arabic Egypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Support:
 - en_us: English (EN) United States ***[Default locale]***
 - zh_cn: Chinese (ZH) Simplified
 - pt_br: Portuguese (PT) Brazil
+- ar_eg: Arabic (ar) Egypt
 - es: Spanish (ES)
 - ro: Romanian (RO)
 - bn: Bengali (BN)

--- a/lib/src/i18n/date_picker_i18n.dart
+++ b/lib/src/i18n/date_picker_i18n.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 part 'strings_en_us.dart';
 part 'strings_zh_cn.dart';
 part 'strings_pt_br.dart';
+part 'strings_ar_eg.dart';
 part 'strings_es.dart';
 part 'strings_ro.dart';
 part 'strings_bn.dart';
@@ -55,6 +56,9 @@ enum DateTimePickerLocale {
   /// Arabic (ar)
   ar,
 
+  /// Arabic (ar) Egypt
+  ar_eg,
+
   /// Japanese (JP)
   jp,
 
@@ -82,6 +86,7 @@ const Map<DateTimePickerLocale, _StringsI18n> datePickerI18n = {
   DateTimePickerLocale.en_us: const _StringsEnUs(),
   DateTimePickerLocale.zh_cn: const _StringsZhCn(),
   DateTimePickerLocale.pt_br: const _StringsPtBr(),
+  DateTimePickerLocale.ar_eg: const _StringsArEg(),
   DateTimePickerLocale.es: const _StringsEs(),
   DateTimePickerLocale.ro: const _StringsRo(),
   DateTimePickerLocale.bn: const _StringsBn(),

--- a/lib/src/i18n/strings_ar_eg.dart
+++ b/lib/src/i18n/strings_ar_eg.dart
@@ -1,0 +1,60 @@
+part of 'date_picker_i18n.dart';
+
+/// Arabic (ar) Egypt
+class _StringsArEg extends _StringsI18n {
+  const _StringsArEg();
+
+  @override
+  String getCancelText() {
+    return 'إلغاء';
+  }
+
+  @override
+  String getDoneText() {
+    return 'تم';
+  }
+
+  @override
+  List<String> getMonths() {
+    return [
+      "يناير",
+      "فبراير",
+      "مارس",
+      "أبريل",
+      "مايو",
+      "يونيو",
+      "يوليو",
+      "أغسطس",
+      "سبتمبر",
+      "أكتوبر",
+      "نوفمبر",
+      "ديسمبر"
+    ];
+  }
+
+  @override
+  List<String> getWeeksFull() {
+    return [
+      "الأثنين",
+      "الثلاثاء",
+      "الأربعاء",
+      "الخميس",
+      "الجمعه",
+      "السبت",
+      "الأحد",
+    ];
+  }
+
+  @override
+  List<String> getWeeksShort() {
+        return [
+      "ن",
+      "ث",
+      "ر",
+      "خ",
+      "ج",
+      "س",
+      "ح",
+    ];
+  }
+}


### PR DESCRIPTION
The Arabic Egypt months is used in Egypt and the Gulf countries (GCC)