### PR TITLE
Make DateTimePickerTheme compatible with #51495

### DIFF
--- a/lib/src/date_picker_theme.dart
+++ b/lib/src/date_picker_theme.dart
@@ -20,7 +20,7 @@ const double DATETIME_PICKER_ITEM_HEIGHT = 36.0;
 const TextStyle DATETIME_PICKER_ITEM_TEXT_STYLE =
     const TextStyle(color: Color(0xFF000046), fontSize: 16.0);
 
-class DateTimePickerTheme extends Diagnosticable {
+class DateTimePickerTheme with Diagnosticable {
   final cancelDefault = const Text('OK');
 
   /// DateTimePicker theme.


### PR DESCRIPTION
Convert Diagnosticable to a mixin [#51495](https://github.com/flutter/flutter/pull/51495)